### PR TITLE
remove csv since its part of the standard lib

### DIFF
--- a/logstash-output-google_bigquery.gemspec
+++ b/logstash-output-google_bigquery.gemspec
@@ -21,8 +21,6 @@ Gem::Specification.new do |s|
 
   # Gem dependencies
   s.add_runtime_dependency 'logstash', '>= 1.4.0', '< 2.0.0'
-
-  s.add_runtime_dependency 'csv'
   s.add_runtime_dependency 'google-api-client'
 
 end

--- a/spec/outputs/google_bigquery_spec.rb
+++ b/spec/outputs/google_bigquery_spec.rb
@@ -1,1 +1,6 @@
+# encoding: utf-8
 require 'spec_helper'
+require 'logstash/outputs/google_bigquery'
+
+describe LogStash::Outputs::GoogleBigQuery do
+end


### PR DESCRIPTION
No need to define a CSV gem its part of the std lib.
