### PR TITLE
Fix LOGSTASH-2164

### DIFF
--- a/lib/logstash/outputs/google_bigquery.rb
+++ b/lib/logstash/outputs/google_bigquery.rb
@@ -503,7 +503,7 @@ class LogStash::Outputs::GoogleBigQuery < LogStash::Outputs::Base
       table_id = @table_prefix + "_" + get_date_pattern(filename)
       # BQ does not accept anything other than alphanumeric and _
       # Ref: https://developers.google.com/bigquery/browser-tool-quickstart?hl=en
-      table_id = table_id.gsub!(':','_').gsub!('-', '_')
+      table_id = table_id.gsub(':','_').gsub('-', '_')
 
       @logger.debug("BQ: upload object.",
                     :filename => filename,

--- a/lib/logstash/outputs/google_bigquery.rb
+++ b/lib/logstash/outputs/google_bigquery.rb
@@ -503,7 +503,7 @@ class LogStash::Outputs::GoogleBigQuery < LogStash::Outputs::Base
       table_id = @table_prefix + "_" + get_date_pattern(filename)
       # BQ does not accept anything other than alphanumeric and _
       # Ref: https://developers.google.com/bigquery/browser-tool-quickstart?hl=en
-      table_id = table_id.gsub(':','_').gsub('-', '_')
+      table_id.tr!(':-','_')
 
       @logger.debug("BQ: upload object.",
                     :filename => filename,


### PR DESCRIPTION
As discussed in https://logstash.jira.com/browse/LOGSTASH-2164
gsub!() is dangerous to use like this as it returns nil when no substitutions are made.
Replacing with gsub() avoid this.
Comes from https://github.com/elasticsearch/logstash-contrib/pull/52