### PR TITLE
allow loading a subset of fields into BigQuery

### DIFF
--- a/lib/logstash/outputs/google_bigquery.rb
+++ b/lib/logstash/outputs/google_bigquery.rb
@@ -101,6 +101,10 @@ class LogStash::Outputs::GoogleBigQuery < LogStash::Outputs::Base
   # Example: path:STRING,status:INTEGER,score:FLOAT
   config :csv_schema, :validate => :string, :required => true
 
+  # Indicates if BigQuery should allow extra values that are not represented in the table schema.
+  # If true, the extra values are ignored. If false, records with extra columns are treated as bad records, and if there are too many bad records, an invalid error is returned in the job result. The default value is false.
+  config :ignore_unknown_values, :validate => :boolean, :default => false
+
   # Path to private key file for Google Service Account.
   config :key_path, :validate => :string, :required => true
 
@@ -519,7 +523,8 @@ class LogStash::Outputs::GoogleBigQuery < LogStash::Outputs::Base
               "tableId" => table_id
             },
             'createDisposition' => 'CREATE_IF_NEEDED',
-            'writeDisposition' => 'WRITE_APPEND'
+            'writeDisposition' => 'WRITE_APPEND',
+            'ignoreUnknownValues' => @ignore_unknown_values
           }
         }
       }


### PR DESCRIPTION
Allow input records to contain fields that are not in the BQ schema. These fields are ignored.