### PR TITLE
Raise the error message when BQ returned an error

### DIFF
--- a/lib/logstash/outputs/google_bigquery.rb
+++ b/lib/logstash/outputs/google_bigquery.rb
@@ -468,6 +468,12 @@ class LogStash::Outputs::GoogleBigQuery < LogStash::Outputs::Base
     @client.authorization = service_account.authorize
   end
 
+  def raise_if_error(response)
+    if response.has_key?("error")
+      raise response["error"]["message"]
+    end
+  end
+
   ##
   # Uploads a local file to the configured bucket.
   def get_job_status(job_id)
@@ -483,9 +489,7 @@ class LogStash::Outputs::GoogleBigQuery < LogStash::Outputs::Base
       @logger.debug("BQ: successfully invoked API.",
                     :response => response)
 
-      if response.has_key?("error")
-        raise response["error"]
-      end
+      raise_if_error(response)
 
       # Successful invocation
       contents = response["status"]
@@ -535,7 +539,11 @@ class LogStash::Outputs::GoogleBigQuery < LogStash::Outputs::Base
                                       },
                                       :media => media)
 
-      job_id = LogStash::Json.load(insert_result.response.body)["jobReference"]["jobId"]
+      response_body = LogStash::Json.load(insert_result.response.body)
+
+      raise_if_error(response_body)
+
+      job_id = response_body["jobReference"]["jobId"]
       @logger.debug("BQ: multipart insert",
                     :job_id => job_id)
       return job_id


### PR DESCRIPTION
Hi,

Just a minor patch for making error messages bit nicer. Since `upload_object` does not handle an error API returns, I've got the following error and it gave me a hard time...

    BQ: failed to upload file {:exception=>#<NoMethodError: undefined method `[]' for nil:NilClass>, :level=>:error}

This PR simply applies the same error handling as `get_job_status` already does to `upload_object`.

Also, throwing `response["error"]` leads to `
BQ: failed to upload file {:exception=>#<TypeError: exception class/object expected>, :level=>:error}` since the object is not an exception. This PR throws the error message instead, which is a string.