### PR TITLE
Fix log files never closed after upload

### DIFF
--- a/lib/logstash/outputs/google_bigquery.rb
+++ b/lib/logstash/outputs/google_bigquery.rb
@@ -565,6 +565,7 @@ class LogStash::Outputs::GoogleBigQuery < LogStash::Outputs::Base
                                       },
                                       :media => media)
 
+      media.close()
       response_body = LogStash::Json.load(insert_result.response.body)
 
       raise_if_error(response_body)


### PR DESCRIPTION
Log file uploader kept a filehandler open on the log file, resulting in
file space never behing recovered, even after the deleter would have
cleaned them up.