### PR TITLE
Upper bound on the Google API client dependency

### DIFF
--- a/logstash-output-google_bigquery.gemspec
+++ b/logstash-output-google_bigquery.gemspec
@@ -21,8 +21,8 @@ Gem::Specification.new do |s|
 
   # Gem dependencies
   s.add_runtime_dependency "logstash-core", ">= 2.0.0.beta2", "< 3.0.0"
-  s.add_runtime_dependency 'google-api-client'
+  s.add_runtime_dependency 'google-api-client', '< 0.9'
+  s.add_runtime_dependency 'mime-types', '>= 2.6', '< 3.0'
 
   s.add_development_dependency 'logstash-devutils'
 end
-


### PR DESCRIPTION
The latest version of the Google API client gem is [incompatible](https://github.com/google/google-api-ruby-client/blob/master/MIGRATING.md) with the previous version and with the code in this plugin. The gemspec needs an upper version bound on this dependency. Without this change, this plugin doesn't work at all.