### PR TITLE
Update plugin api

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 sudo: false
+jdk:
+ - oraclejdk8
 language: ruby
 cache: bundler
 rvm:
-  - jruby-1.7.23
-script: 
-  - bundle exec rspec spec
+ - jruby-1.7.25
+script:
+ - bundle exec rspec spec

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,15 @@
-# 2.0.5
+## 3.0.0
+  - Breaking: Updated plugin to use new Java Event APIs
+  - relax contrains on logstash-core-plugin-api
+  - mark this plugin as concurrency :single
+  - update .travis.yml
+
+## 2.0.5
   - Depend on logstash-core-plugin-api instead of logstash-core, removing the need to mass update plugins on major releases of logstash
-# 2.0.4
+
+## 2.0.4
   - New dependency requirements for logstash-core for the 5.0 release
+
 ## 2.0.3
  - Add support for specifying schema as a hash
  - Bubble up error message that BQ returns on an error

--- a/lib/logstash/outputs/google_bigquery.rb
+++ b/lib/logstash/outputs/google_bigquery.rb
@@ -89,6 +89,8 @@ require "logstash/json"
 class LogStash::Outputs::GoogleBigQuery < LogStash::Outputs::Base
   config_name "google_bigquery"
 
+  concurrency :single
+
   # Google Cloud Project ID (number, not Project Name!).
   config :project_id, :validate => :string, :required => true
 
@@ -208,12 +210,10 @@ class LogStash::Outputs::GoogleBigQuery < LogStash::Outputs::Base
   # file, flushing depending on flush interval configuration.
   public
   def receive(event)
-    
-
     @logger.debug("BQ: receive method called", :event => event)
 
     # Message must be written as json
-    message = event.to_json
+    message = LogStash::Json.dump(event.to_hash)
     # Remove "@" from property names
     message = message.gsub(/\"@(\w+)\"/, '"\1"')
 

--- a/logstash-output-google_bigquery.gemspec
+++ b/logstash-output-google_bigquery.gemspec
@@ -1,7 +1,6 @@
 Gem::Specification.new do |s|
-
   s.name            = 'logstash-output-google_bigquery'
-  s.version         = '2.0.5'
+  s.version         = '3.0.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Plugin to upload log events to Google BigQuery (BQ)"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"
@@ -20,8 +19,10 @@ Gem::Specification.new do |s|
   s.metadata = { "logstash_plugin" => "true", "logstash_group" => "output" }
 
   # Gem dependencies
-  s.add_runtime_dependency "logstash-core-plugin-api", "~> 1.0"
-  s.add_runtime_dependency 'google-api-client'
+  s.add_runtime_dependency 'google-api-client', '0.8.7'
+  s.add_runtime_dependency 'logstash-codec-plain'
+  s.add_runtime_dependency 'mime-types', '2.6.2'
+  s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
 
   s.add_development_dependency 'logstash-devutils'
 end


### PR DESCRIPTION
  - Breaking: Updated plugin to use new Java Event APIs
  - relax contrains on logstash-core-plugin-api
  - mark this plugin as concurrency :single
  - update .travis.yml
  - freeze google-api-client and mime-types