### PR TITLE
pin google-api-client dependency to 0.8.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2.0.6
+  - Pin version of gems whose latest releases only work with ruby 2.x
+
 # 2.0.5
   - Depend on logstash-core-plugin-api instead of logstash-core, removing the need to mass update plugins on major releases of logstash
 # 2.0.4

--- a/logstash-output-google_bigquery.gemspec
+++ b/logstash-output-google_bigquery.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-output-google_bigquery'
-  s.version         = '2.0.5'
+  s.version         = '2.0.6'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Plugin to upload log events to Google BigQuery (BQ)"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
 
   # Gem dependencies
   s.add_runtime_dependency "logstash-core-plugin-api", "~> 1.0"
-  s.add_runtime_dependency 'google-api-client'
+  s.add_runtime_dependency 'google-api-client', "~> 0.8.7" # version 0.9.x needs ruby 2.x
 
   s.add_development_dependency 'logstash-devutils'
 end


### PR DESCRIPTION
fixes https://github.com/logstash-plugins/logstash-output-google_bigquery/issues/21 for core-plugin-api-v1 (logstash <= 2.3.x)