### PR TITLE
Add file recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 3.2.0
+  - Add file recovery when plugin crashes
+
 # 3.1.0
   - Fix error checking in the plugin to properly handle failed inserts
 

--- a/logstash-output-google_bigquery.gemspec
+++ b/logstash-output-google_bigquery.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-google_bigquery'
-  s.version         = '3.1.0'
+  s.version         = '3.2.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Plugin to upload log events to Google BigQuery (BQ)"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
I'm adding a couple of methods to handle real file recovery for the plugin. The recovery happens in two phases:

1. Find all files in all logstash-bq directories to recover
2. For each file, recover it by inserting into upload_queue or delete_queue depending on its state

I've removed the old delete_queue recovery in the delete thread, as it didn't work when temp_directory was empty--the new code handles this.