### PR TITLE
Fix documentation error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.0.1
+ - Documentation cleanup
+
 ## 4.0.0
 
 **Breaking**: the update to 4.0.0 requires that you use an IAM JSON credentials file

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -207,7 +207,7 @@ mutate {
 
 [id="plugins-{type}s-{plugin}-json_key_file"]
 ===== `json_key_file`
-new[4.0.0, Replaces <<plugins-{type}s-{plugin}-key_password>>, <<plugins-{type}s-{plugin}-key_path>> and <<plugins-{type}s-{plugin}-service_account>>]]
+new[4.0.0, Replaces <<plugins-{type}s-{plugin}-key_password>>, <<plugins-{type}s-{plugin}-key_path>> and <<plugins-{type}s-{plugin}-service_account>>]
   * Value type is <<string,string>>
   * Default value is `nil`
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -341,6 +341,18 @@ Events are uploaded in real-time without being stored to disk.
   for your use-case and consider using
   https://www.elastic.co/guide/en/logstash/current/persistent-queues.html[Logstash Persistent Queues]
 
+[id="plugins-{type}s-{plugin}-uploader_interval_secs"]
+===== `uploader_interval_secs`
+
+  * Value type is <<number,number>>
+  * Default value is `60`
+
+Uploader interval when uploading new files to BigQuery. Adjust time based
+on your time pattern (for example, for hourly files, this interval can be
+around one hour).
+
+**Deprecated:** this field is no longer used.
+
 
 [id="plugins-{type}s-{plugin}-common-options"]
 include::{include_path}/{type}.asciidoc[]

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -114,7 +114,7 @@ output plugins.
 
 [id="plugins-{type}s-{plugin}-batch_size"]
 ===== `batch_size`
-
+new[4.0.0]
   * Value type is <<number,number>>
   * Default value is `128`
 
@@ -122,7 +122,7 @@ The number of messages to upload at a single time. (< 1000, default: 128)
 
 [id="plugins-{type}s-{plugin}-batch_size_bytes"]
 ===== `batch_size_bytes`
-
+new[4.0.0]
   * Value type is <<number,number>>
   * Default value is `1_000_000`
 
@@ -157,15 +157,13 @@ Must Time.strftime patterns: www.ruby-doc.org/core-2.0/Time.html#method-i-strfti
 
 [id="plugins-{type}s-{plugin}-deleter_interval_secs"]
 ===== `deleter_interval_secs`
+deprecated[4.0.0, Events are uploaded in real-time without being stored to disk.]
 
   * Value type is <<number,number>>
 
-**Deprecated:** this field is no longer used because temporary files are no longer
-stored on the hard drive.
-
 [id="plugins-{type}s-{plugin}-error_directory"]
 ===== `error_directory`
-
+new[4.0.0]
   * This is a required setting.
   * Value type is <<string,string>>
   * Default value is `"/tmp/bigquery"`.
@@ -209,7 +207,7 @@ mutate {
 
 [id="plugins-{type}s-{plugin}-json_key_file"]
 ===== `json_key_file`
-
+new[4.0.0, Replaces <<plugins-{type}s-{plugin}-key_password>>, <<plugins-{type}s-{plugin}-key_path>> and <<plugins-{type}s-{plugin}-service_account>>]]
   * Value type is <<string,string>>
   * Default value is `nil`
 
@@ -255,18 +253,17 @@ json_schema => {
 
 [id="plugins-{type}s-{plugin}-key_password"]
 ===== `key_password`
+deprecated[4.0.0, Replaced by `json_key_file` or by using ADC. See <<plugins-{type}s-{plugin}-json_key_file>>]
 
   * Value type is <<string,string>>
-
-**Deprecated:** this field is no longer needed with `json_key_file` or ADC.
 
 
 [id="plugins-{type}s-{plugin}-key_path"]
 ===== `key_path`
-
   * Value type is <<string,string>>
 
 **Obsolete:** The PKCS12 key file format is no longer supported.
+
 Please use one of the following mechanisms:
 
   * https://cloud.google.com/docs/authentication/production[Application Default Credentials (ADC)],
@@ -287,6 +284,7 @@ Google Cloud Project ID (number, not Project Name!).
 
 [id="plugins-{type}s-{plugin}-service_account"]
 ===== `service_account`
+deprecated[4.0.0, Replaced by `json_key_file` or by using ADC. See <<plugins-{type}s-{plugin}-json_key_file>>]
 
   * Value type is <<string,string>>
 
@@ -313,45 +311,24 @@ date suffix.
 
 [id="plugins-{type}s-{plugin}-temp_directory"]
 ===== `temp_directory`
-
+deprecated[4.0.0, Events are uploaded in real-time without being stored to disk.]
   * Value type is <<string,string>>
-
-**Deprecated:** this field is no longer used.
-Events are uploaded in real-time without being stored to disk.
-
- * Events that failed to be uploaded will be stored in <<plugins-{type}s-{plugin}-error_directory>>.
- * There is a small fee to insert data into BigQuery using the streaming API.
-   https://cloud.google.com/bigquery/pricing[Pricing Information]
- * This plugin buffers events in-memory, so make sure the flush configurations are appropriate
-  for your use-case and consider using
-  https://www.elastic.co/guide/en/logstash/current/persistent-queues.html[Logstash Persistent Queues]
 
 [id="plugins-{type}s-{plugin}-temp_file_prefix"]
 ===== `temp_file_prefix`
+deprecated[4.0.0, Events are uploaded in real-time without being stored to disk]
 
   * Value type is <<string,string>>
 
-**Deprecated:** this field is no longer used.
-Events are uploaded in real-time without being stored to disk.
-
- * Events that failed to be uploaded will be stored in <<plugins-{type}s-{plugin}-error_directory>>.
- * There is a small fee to insert data into BigQuery using the streaming API.
-   https://cloud.google.com/bigquery/pricing[Pricing Information]
- * This plugin buffers events in-memory, so make sure the flush configurations are appropriate
-  for your use-case and consider using
-  https://www.elastic.co/guide/en/logstash/current/persistent-queues.html[Logstash Persistent Queues]
-
 [id="plugins-{type}s-{plugin}-uploader_interval_secs"]
 ===== `uploader_interval_secs`
-
+deprecated[4.0.0, This field is no longer used]
   * Value type is <<number,number>>
   * Default value is `60`
 
 Uploader interval when uploading new files to BigQuery. Adjust time based
 on your time pattern (for example, for hourly files, this interval can be
 around one hour).
-
-**Deprecated:** this field is no longer used.
 
 
 [id="plugins-{type}s-{plugin}-common-options"]

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -75,7 +75,6 @@ https://cloud.google.com/docs/authentication/production[Application Default Cred
 * https://cloud.google.com/docs/authentication/production[Application Default Credentials (ADC) Overview]
 * https://cloud.google.com/bigquery/[BigQuery Introduction]
 * https://cloud.google.com/bigquery/docs/schemas[BigQuery Schema Formats and Types]
-* https://cloud.google.com/bigquery/pricing[Pricing Information]
 
 [id="plugins-{type}s-{plugin}-options"]
 ==== Google BigQuery Output Configuration Options
@@ -114,7 +113,9 @@ output plugins.
 
 [id="plugins-{type}s-{plugin}-batch_size"]
 ===== `batch_size`
-new[4.0.0]
+
+added[4.0.0]
+
   * Value type is <<number,number>>
   * Default value is `128`
 
@@ -122,7 +123,9 @@ The number of messages to upload at a single time. (< 1000, default: 128)
 
 [id="plugins-{type}s-{plugin}-batch_size_bytes"]
 ===== `batch_size_bytes`
-new[4.0.0]
+
+added[4.0.0]
+
   * Value type is <<number,number>>
   * Default value is `1_000_000`
 
@@ -157,13 +160,15 @@ Must Time.strftime patterns: www.ruby-doc.org/core-2.0/Time.html#method-i-strfti
 
 [id="plugins-{type}s-{plugin}-deleter_interval_secs"]
 ===== `deleter_interval_secs`
+
 deprecated[4.0.0, Events are uploaded in real-time without being stored to disk.]
 
   * Value type is <<number,number>>
 
 [id="plugins-{type}s-{plugin}-error_directory"]
 ===== `error_directory`
-new[4.0.0]
+added[4.0.0]
+
   * This is a required setting.
   * Value type is <<string,string>>
   * Default value is `"/tmp/bigquery"`.
@@ -207,7 +212,9 @@ mutate {
 
 [id="plugins-{type}s-{plugin}-json_key_file"]
 ===== `json_key_file`
-new[4.0.0, Replaces <<plugins-{type}s-{plugin}-key_password>>, <<plugins-{type}s-{plugin}-key_path>> and <<plugins-{type}s-{plugin}-service_account>>]
+
+added[4.0.0, Replaces <<plugins-{type}s-{plugin}-key_password>>, <<plugins-{type}s-{plugin}-key_path>> and <<plugins-{type}s-{plugin}-service_account>>]
+
   * Value type is <<string,string>>
   * Default value is `nil`
 
@@ -253,6 +260,7 @@ json_schema => {
 
 [id="plugins-{type}s-{plugin}-key_password"]
 ===== `key_password`
+
 deprecated[4.0.0, Replaced by `json_key_file` or by using ADC. See <<plugins-{type}s-{plugin}-json_key_file>>]
 
   * Value type is <<string,string>>
@@ -260,6 +268,7 @@ deprecated[4.0.0, Replaced by `json_key_file` or by using ADC. See <<plugins-{ty
 
 [id="plugins-{type}s-{plugin}-key_path"]
 ===== `key_path`
+
   * Value type is <<string,string>>
 
 **Obsolete:** The PKCS12 key file format is no longer supported.
@@ -284,12 +293,10 @@ Google Cloud Project ID (number, not Project Name!).
 
 [id="plugins-{type}s-{plugin}-service_account"]
 ===== `service_account`
+
 deprecated[4.0.0, Replaced by `json_key_file` or by using ADC. See <<plugins-{type}s-{plugin}-json_key_file>>]
 
   * Value type is <<string,string>>
-
-**Deprecated:** this field is no longer used because it is contained in the `json_key_file` or
-the Application Default Credentials (ADC) environment variables.
 
 [id="plugins-{type}s-{plugin}-table_prefix"]
 ===== `table_prefix` 
@@ -311,18 +318,23 @@ date suffix.
 
 [id="plugins-{type}s-{plugin}-temp_directory"]
 ===== `temp_directory`
+
 deprecated[4.0.0, Events are uploaded in real-time without being stored to disk.]
+
   * Value type is <<string,string>>
 
 [id="plugins-{type}s-{plugin}-temp_file_prefix"]
 ===== `temp_file_prefix`
+
 deprecated[4.0.0, Events are uploaded in real-time without being stored to disk]
 
   * Value type is <<string,string>>
 
 [id="plugins-{type}s-{plugin}-uploader_interval_secs"]
 ===== `uploader_interval_secs`
+
 deprecated[4.0.0, This field is no longer used]
+
   * Value type is <<number,number>>
   * Default value is `60`
 

--- a/logstash-output-google_bigquery.gemspec
+++ b/logstash-output-google_bigquery.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-google_bigquery'
-  s.version         = '4.0.0'
+  s.version         = '4.0.1'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Writes events to Google BigQuery"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Missing reference to deprecated field causes the docs to fail to build,
 this commit adds the reference back.

Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
