### PR TITLE
use only table_prefix as table name in case no valid date pattern is used

### DIFF
--- a/lib/logstash/outputs/google_bigquery.rb
+++ b/lib/logstash/outputs/google_bigquery.rb
@@ -205,7 +205,11 @@ class LogStash::Outputs::GoogleBigQuery < LogStash::Outputs::Base
     time ||= Time.now
 
     str_time = time.strftime(@date_pattern)
-    table_id = @table_prefix + @table_separator + str_time
+    if str_time.to_s.empty?
+        table_id = @table_prefix
+    else
+        table_id = @table_prefix + @table_separator + str_time
+    end
 
     # BQ does not accept anything other than alphanumeric and _
     # Ref: https://developers.google.com/bigquery/browser-tool-quickstart?hl=en


### PR DESCRIPTION
Before this patch, in case date_pattern = "" than the table name would
have been `<table_prefix><table_separator>` insteadd of just `<table_prefix>`.

Example

config:
- table_prefix => 'my_table'
- table_separator => '_'
- date_pattern => ""

result
- table_name = 'my_table_'

Now the table_name will be 'my_table'.

Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/

Fixes https://github.com/logstash-plugins/logstash-output-google_bigquery/issues/43


**NOTE**: This changes the table generation and addressing so it might be a breaking change.
