### PR TITLE
Flush batch after shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.1.2
+ - Fixed issue where Logstash shutdown could cause data loss due to not flushing buffers on close [#52](https://github.com/logstash-plugins/logstash-output-google_bigquery/pull/52)
+
 ## 4.1.1
  - Fixed inaccuracies in documentation [#46](https://github.com/logstash-plugins/logstash-output-google_bigquery/pull/46) 
 

--- a/lib/logstash/outputs/google_bigquery.rb
+++ b/lib/logstash/outputs/google_bigquery.rb
@@ -277,7 +277,7 @@ class LogStash::Outputs::GoogleBigQuery < LogStash::Outputs::Base
   def init_batcher_flush_thread
     @flush_thread = Thread.new do
       until stopping?
-        sleep @flush_interval_secs
+        Stud.stoppable_sleep(@flush_interval_secs) { stopping? }
 
         @batcher.enqueue(nil) { |batch| publish(batch) }
       end

--- a/lib/logstash/outputs/google_bigquery.rb
+++ b/lib/logstash/outputs/google_bigquery.rb
@@ -182,7 +182,7 @@ class LogStash::Outputs::GoogleBigQuery < LogStash::Outputs::Base
     @schema = LogStash::Outputs::BigQuery::Schema.parse_csv_or_json @csv_schema, @json_schema
     @bq_client = LogStash::Outputs::BigQuery::StreamingClient.new @json_key_file, @project_id, @logger
     @batcher = LogStash::Outputs::BigQuery::Batcher.new @batch_size, @batch_size_bytes
-    @stopping = Concurrent::AtomicBoolean.new
+    @stopping = Concurrent::AtomicBoolean.new(false)
 
     init_batcher_flush_thread
   end

--- a/lib/logstash/outputs/google_bigquery.rb
+++ b/lib/logstash/outputs/google_bigquery.rb
@@ -292,5 +292,8 @@ class LogStash::Outputs::GoogleBigQuery < LogStash::Outputs::Base
     @stopping.make_true
     @flush_thread.wakeup
     @flush_thread.join
+    # Final flush to publish any events published if a pipeline receives a shutdown signal after flush thread
+    # has begun flushing.
+    @batcher.enqueue(nil) { |batch| publish(batch) }
   end
 end

--- a/logstash-output-google_bigquery.gemspec
+++ b/logstash-output-google_bigquery.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-google_bigquery'
-  s.version         = '4.1.1'
+  s.version         = '4.1.2'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Writes events to Google BigQuery"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Fixes issue where when Logstash shuts down, even during a clean shutdown,
this plugin will not flush any messages residing in the buffer,
potentially resulting in data loss.

Fixes #51

