### PR TITLE
Doc: Replace cross-document links with attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.1.5
+ - [DOC] Updated links to use shared attributes [#61](https://github.com/logstash-plugins/logstash-output-google_bigquery/pull/61)
+
 ## 4.1.4
  - Changed concurrency to :shared and publish outside of synchronized code [#60](https://github.com/logstash-plugins/logstash-output-google_bigquery/pull/60)
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -36,7 +36,7 @@ hold the tables this plugin generates.
 
 You must also grant the service account this plugin uses access to the dataset.
 
-You can use https://www.elastic.co/guide/en/logstash/current/event-dependent-configuration.html[Logstash conditionals]
+You can use {logstash-ref}/event-dependent-configuration.html[Logstash conditionals]
 and multiple configuration blocks to upload events with different structures.
 
 ===== Usage
@@ -67,7 +67,7 @@ https://cloud.google.com/docs/authentication/production[Application Default Cred
 * There is a small fee to insert data into BigQuery using the streaming API.
 * This plugin buffers events in-memory, so make sure the flush configurations are appropriate
   for your use-case and consider using
-  https://www.elastic.co/guide/en/logstash/current/persistent-queues.html[Logstash Persistent Queues].
+  {logstash-ref}/persistent-queues.html[Logstash Persistent Queues].
 * Events will be flushed when <<plugins-{type}s-{plugin}-batch_size>>, <<plugins-{type}s-{plugin}-batch_size_bytes>>, or <<plugins-{type}s-{plugin}-flush_interval_secs>> is met, whatever comes first.
   If you notice a delay in your processing or low throughput, try adjusting those settings.
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -58,7 +58,6 @@ output {
 --------------------------
 
 <1> Specify either a csv_schema or a json_schema.
-
 <2> If the key is not used, then the plugin tries to find
 https://cloud.google.com/docs/authentication/production[Application Default Credentials]
 
@@ -75,7 +74,7 @@ https://cloud.google.com/docs/authentication/production[Application Default Cred
 
 * https://cloud.google.com/docs/authentication/production[Application Default Credentials (ADC) Overview]
 * https://cloud.google.com/bigquery/[BigQuery Introduction]
-* https://cloud.google.com/bigquery/quota[BigQuery Quotas and Limits]
+* https://cloud.google.com/bigquery/quotas[BigQuery Quotas and Limits]
 * https://cloud.google.com/bigquery/docs/schemas[BigQuery Schema Formats and Types]
 
 [id="plugins-{type}s-{plugin}-options"]

--- a/logstash-output-google_bigquery.gemspec
+++ b/logstash-output-google_bigquery.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-google_bigquery'
-  s.version         = '4.1.4'
+  s.version         = '4.1.5'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Writes events to Google BigQuery"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Standardize links to Elastic docs to use shared attributes.
Correct link to Quotas and LImits to close #58
Bump to v.4.1.5