### PR TITLE
Add table_name setting

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -340,6 +340,15 @@ BigQuery table separator to be added between the table_prefix and the
 date suffix.
 
 [id="plugins-{type}s-{plugin}-temp_directory"]
+===== `table_name`
+
+  * Value type is <<string,string>>
+  * Default value is `nil`
+
+BigQuery table name to be used when inserting data into an existing table.
+(Useful when using partitioned table)
+
+[id="plugins-{type}s-{plugin}-table_name"]
 ===== `temp_directory`
 
 deprecated[4.0.0, Events are uploaded in real-time without being stored to disk.]


### PR DESCRIPTION
The `table_name` setting allows declaration of an existing table where all the data needs to be inserted instead of creating new tables based on the timestamp. This feature is particularly helpful when working with partitioned tables in BigQuery which uses a single table & optimises queries using the partitioning column.

`table_prefix`, `table_separator`, `csv_schema`, `json_schema` are ignored when this setting is used.

This PR addresses #42  as well.